### PR TITLE
Fix EOS Public Explorer data

### DIFF
--- a/lambda.py
+++ b/lambda.py
@@ -539,7 +539,7 @@ def lambda_handler(event, context):
                 "environments": [{
                     "network": "MainNet",
                     "bgURL": "https://www.bitgo.com/api/v2/eos/public/block/latest",
-                    "publicURL": "https://api.eosnewyork.io/v1/chain/get_info",
+                    "publicURL": "https://bp.cryptolions.io/v1/chain/get_info",
                     "apiHandler": EOSAPIHander,
                 },
                 {


### PR DESCRIPTION
The EOS public node (eosnewyork) is down, as the company went out of
business. This commit updates it to use another one (cryptolions) which
should return valid chain data for us to compare to.